### PR TITLE
Update TimePicker.vue

### DIFF
--- a/src/components/menus/TimePicker.vue
+++ b/src/components/menus/TimePicker.vue
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 import { useVisualizationStore } from '@/stores/visualizationstore'
 
 const props = defineProps<{ title: string }>()
-const emit = defineEmits(['update:timeInstant'])
+const emit = defineEmits(['update:formattedDate'])
 const visualizationStore = useVisualizationStore()
 
 // Split the incoming timeInstant into date and time parts
@@ -66,7 +66,7 @@ const formattedDate = computed({
 
 watch(formattedDate, (newVal, oldVal) => {
   if (newVal !== oldVal && !manualInputError.value) {
-    emit('update:timeInstant', newVal)
+    emit('update:formattedDate', newVal)
     console.log('[TimePicker] Time instant updated:', newVal)
   }
 })


### PR DESCRIPTION
The `TimePicker` component currently does not emit the selected time range values to the store because the emitted value  `update:timeInstant` does not match the bounded v-model name `formattedDate`. I changed this to match and was able to create visualizations using historical data.