### PR TITLE
OSH-JS Fixes to LoB

### DIFF
--- a/lib/osh-js/source/core/ui/view/map/LeafletView.js
+++ b/lib/osh-js/source/core/ui/view/map/LeafletView.js
@@ -439,7 +439,7 @@ class LeafletView extends MapView {
         }
 
         marker.setZIndexOffset(properties.zIndex);
-        marker.id = properties.id + '$' + properties.markerId;
+        marker.id = properties.id + '$' + (properties.markerId ?? properties.id);
         marker.addTo(this.map);
         if (properties.hasOwnProperty(properties.orientation)) {
             marker.setRotationAngle(properties.orientation.heading);
@@ -666,17 +666,6 @@ class LeafletView extends MapView {
         let lob = this.getLob(props);
         this.updateMarker(props);
         this.updatePolyline(props);
-    }
-
-    /**
-     * Removes a line of bearing (lob) from the map.
-     * @param props
-     */
-    removeLob(props) {
-        let marker = this.getMarker(props);
-        this.map.removeLayer(marker);
-        let polyline = this.getPolyline(props);
-        this.map.removeLayer(polyline);
     }
 
     attachTo(parentElement) {

--- a/lib/osh-js/source/core/ui/view/map/MapView.js
+++ b/lib/osh-js/source/core/ui/view/map/MapView.js
@@ -43,8 +43,8 @@ class MapView extends View {
         // map Layer id to array of corresponding draping
         this.layerIdToDrapedImage= {};
 
-		// map Layer id to array of corresponding lobs
-		this.layerIdToLob= {};
+        // map Layer id to array of corresponding lobs
+        this.layerIdToLob= {};
     }
 
     async setData(dataSourceId, data) {
@@ -82,7 +82,8 @@ class MapView extends View {
      * @param {Object} markerObject - the Map marker object
      */
     async addMarkerToLayer(props, markerObject) {
-        this.layerIdToMarkers[props.markerId] = markerObject;
+        // Use props.id for LoB
+        this.layerIdToMarkers[props.markerId ?? props.id] = markerObject;
     }
 
     /**
@@ -92,7 +93,8 @@ class MapView extends View {
      * @param {Object} polylineObject - the Map polyline object
      */
     async addPolylineToLayer(props, polylineObject) {
-        this.layerIdToPolylines[props.polylineId] = polylineObject;
+        // Use props.id for LoB
+        this.layerIdToPolylines[props.polylineId ?? props.id] = polylineObject;
     }
 
     /**
@@ -140,10 +142,11 @@ class MapView extends View {
      * @param {PointMarkerLayer.props} props - the Layer Object
      */
     getMarker(props) {
-        if(!(props.markerId in  this.layerIdToMarkers)) {
+        // Use props.id for LoB
+        if(!(props.markerId in this.layerIdToMarkers) && !(props.id in this.layerIdToMarkers)) {
             return null;
         }
-        return this.layerIdToMarkers[props.markerId];
+        return this.layerIdToMarkers[props.markerId ?? props.id];
     }
 
     /**
@@ -194,18 +197,6 @@ class MapView extends View {
      * @protected
      * @param {Ellipse.props} layer - the Layer Object
      */
-    getPolyline(props) {
-        if(!(props.polylineId in  this.layerIdToEllipsoids)) {
-            return null;
-        }
-        return this.layerIdToPolylines[props.polylineId];
-    }
-
-    /**
-     * Get the ellipse associate to the Layer
-     * @protected
-     * @param {Ellipse.props} layer - the Layer Object
-     */
     getEllipse(props) {
         if(!(props.ellipseId in  this.layerIdToEllipsoids)) {
             return null;
@@ -219,10 +210,11 @@ class MapView extends View {
      * @param {Polyline.props} layer - the Layer Object
      */
     getPolyline(props) {
-        if(!(props.polylineId in  this.layerIdToPolylines)) {
+        // Use props.id for LoB
+        if(!(props.polylineId in this.layerIdToPolylines) && !(props.id in this.layerIdToPolylines)) {
             return null;
         }
-        return this.layerIdToPolylines[props.polylineId];
+        return this.layerIdToPolylines[props.polylineId ?? props.id];
     }
 
     /**
@@ -307,8 +299,6 @@ class MapView extends View {
         this.removeDrapedImages(layer);
 
         this.removeFrustums(layer);
-
-        this.removeLob(layer);
 
         super.removeAllFromLayer(layer);
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -215,9 +215,7 @@ function deleteVisualizations(removedVizIds: string[]) {
     // Collect datasource IDs
     removedDsIds.push(...layer.dataSourceIds);
 
-    console.log(mapView.value)
-
-     // Remove layer from the actual map safely
+    // Remove layer from the actual map safely
     try {
       if (mapView.value) {
         mapView.value.removeAllFromLayer(layer);


### PR DESCRIPTION
This contains a fix in the viewer's osh-js to more cleanly add/update/delete LoBs. This fixes some of the bugs that were occurring in deleting LoB visualizations.

‼️ NOTE: This also includes a change in `MapView.js`, where there were duplicate `getPolyline()` functions