### PR TITLE
Change ellipseID prop to ellipseId to be consistent with usage in various map views

### DIFF
--- a/lib/osh-js/core/ui/layer/EllipseLayer.js
+++ b/lib/osh-js/core/ui/layer/EllipseLayer.js
@@ -98,7 +98,7 @@ var EllipseLayer = /** @class */ (function (_super) {
      * @param {Function} [properties.getSemiMinorAxis] - defines a function to return the semiMinorAxis
      * @param {Function} [properties.getHeight] - defines a function to return the height of the ellipse above the ellipsoid
      * @param {Function} [properties.getRotation] - defines a function to return the rotation of the ellipse
-     * @param {Function} [properties.getEllipseID] - map an id to a unique ellipse
+     * @param {Function} [properties.getEllipseId] - map an id to a unique ellipse
      */
     function EllipseLayer(properties) {
         var _this = _super.call(this, properties) || this;
@@ -142,7 +142,7 @@ var EllipseLayer = /** @class */ (function (_super) {
             assertNumber(properties.zIndex, "zIndex");
             props.zIndex = properties.zIndex;
         }
-        this.definedId('ellipseID', props);
+        this.definedId('ellipseId', props);
         if (isDefined(properties.getPosition)) {
             var fn = function (rec, timestamp, options) { return __awaiter(_this, void 0, void 0, function () {
                 var _a, _b;

--- a/lib/osh-js/source/core/ui/layer/EllipseLayer.js
+++ b/lib/osh-js/source/core/ui/layer/EllipseLayer.js
@@ -48,7 +48,7 @@ class EllipseLayer extends Layer {
      * @param {Function} [properties.getSemiMinorAxis] - defines a function to return the semiMinorAxis
      * @param {Function} [properties.getHeight] - defines a function to return the height of the ellipse above the ellipsoid
      * @param {Function} [properties.getRotation] - defines a function to return the rotation of the ellipse
-     * @param {Function} [properties.getEllipseID] - map an id to a unique ellipse
+     * @param {Function} [properties.getEllipseId] - map an id to a unique ellipse
      */
     constructor(properties) {
         super(properties);
@@ -98,7 +98,7 @@ class EllipseLayer extends Layer {
             props.zIndex = properties.zIndex;
         }
 
-        this.definedId('ellipseID', props)
+        this.definedId('ellipseId', props)
 
         if (isDefined(properties.getPosition)){
             let fn = async (rec, timestamp, options) => {


### PR DESCRIPTION
Phil identified this bug in osh-js#mcs-baseline used in Webtak (https://github.com/opensensorhub/osh-js/pull/815)

MapView, CesiumView, and (it seems) also the Open Layers map all read `props.ellipseId`  meaning that the getEllipseID callback never actually drives the lookup key. Every ellipse ends up grouped under the default string 'ellipse', so you can't have multiple distinct ellipses keyed by a user-supplied id. 

This bug stems all the way back to opensensorhub/osh-js before it was cloned into the viewer. 