### PR TITLE
225 validate node reachability prevent duplicate endpoints when adding a new node input validation

### DIFF
--- a/src/components/menus/NodeConfigForm.vue
+++ b/src/components/menus/NodeConfigForm.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { useOSHConnectStore } from '@/stores/oshconnectstore.js';
 import { useUIStore } from '@/stores/uistore';
@@ -15,21 +15,23 @@ const nodeUser = ref('admin');
 const nodePassword = ref('admin');
 const tls = ref(false);
 
-const createNode = () => {
+async function createNode() {
 	// This function will be called when the button is clicked
-	oshconnect.createNode(
+	const result = await oshconnect.createNode(
 		nodeName.value,
 		nodeHost.value,
 		nodePort.value,
 		nodePath.value,
 		nodeUser.value,
 		nodePassword.value,
-		tls.value,
-		this
+		tls.value
 	);
-	oshconnect.fetchSlowResources();
-	cancelForm();
-};
+
+	if (result) {
+		oshconnect.fetchSlowResources();
+		cancelForm();
+	}
+}
 
 const cancelForm = () => {
 	uiStore.nodeConfigFormOpen = false;
@@ -51,7 +53,7 @@ function sanitizeAPIRoot(path) {
 		<v-card-title>Add a New Node</v-card-title>
 
 		<v-card-text>
-			<v-form @submit.prevent="createNode">
+			<v-form @submit.prevent="createNode()">
 				<v-text-field
 					label="Node Name"
 					v-model="nodeName"

--- a/src/components/menus/NodeConfigForm.vue
+++ b/src/components/menus/NodeConfigForm.vue
@@ -2,6 +2,8 @@
 import { ref } from 'vue';
 import { useOSHConnectStore } from '@/stores/oshconnectstore.js';
 import { useUIStore } from '@/stores/uistore';
+import { OSHNode } from '@/lib/OSHConnectDataStructs';
+import { showToast } from '@/composables/useToast';
 
 const oshconnect = useOSHConnectStore().getInstance();
 const uiStore = useUIStore();
@@ -27,9 +29,11 @@ async function createNode() {
 		tls.value
 	);
 
-	if (result) {
+	if (result instanceof OSHNode) {
 		oshconnect.fetchSlowResources();
 		cancelForm();
+	} else {
+		showToast(result.message ?? 'Failed to create node', 'ERROR');
 	}
 }
 

--- a/src/components/menus/NodeConfigForm.vue
+++ b/src/components/menus/NodeConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useOSHConnectStore } from '@/stores/oshconnectstore.js';
 import { useUIStore } from '@/stores/uistore';
 import { OSHNode } from '@/lib/OSHConnectDataStructs';
@@ -8,7 +8,7 @@ import { showToast } from '@/composables/useToast';
 const oshconnect = useOSHConnectStore().getInstance();
 const uiStore = useUIStore();
 
-// Define reactive variables for the form fields
+// Form fields
 const nodeName = ref('Test');
 const nodeHost = ref(window.location.hostname);
 const nodePort = ref('8080');
@@ -16,6 +16,19 @@ const nodePath = ref('sensorhub/api');
 const nodeUser = ref('admin');
 const nodePassword = ref('admin');
 const tls = ref(false);
+
+const isValid = computed(() => {
+	if (
+		nodeName.value &&
+		nodeHost.value &&
+		nodePort.value &&
+		nodePath.value &&
+		nodeUser.value &&
+		nodePassword.value
+	)
+		return true;
+	else return false;
+});
 
 async function createNode() {
 	// This function will be called when the button is clicked
@@ -62,33 +75,50 @@ function sanitizeAPIRoot(path) {
 					label="Node Name"
 					v-model="nodeName"
 					placeholder="Test"
+					class="mb-2"
+					:rules="[(v) => !!v || 'Name is required']"
 					required
 				/>
 				<v-text-field
 					label="Node Host"
 					v-model="nodeHost"
 					placeholder="localhost"
+					:rules="[(v) => !!v || 'Host is required']"
 					required
 				/>
 				<v-text-field
 					label="Node Port"
 					v-model="nodePort"
 					placeholder="8181"
+					type="number"
+					inputmode="numeric"
+					onkeydown="if(['e', 'E', '+', '-'].includes(event.key)) event.preventDefault();"
+					class="mb-2"
+					:rules="[(v) => !!v || 'Port is required']"
 					required
 				/>
 				<v-text-field
 					label="Node Path"
 					v-model="nodePath"
 					placeholder="sensorhub/api"
+					class="mb-2"
+					:rules="[(v) => !!v || 'Path is required']"
+					required
 				/>
 				<v-text-field
 					label="Node User"
 					v-model="nodeUser"
+					class="mb-2"
+					:rules="[(v) => !!v || 'Username is required']"
+					required
 				/>
 				<v-text-field
 					label="Node Password"
 					v-model="nodePassword"
 					type="password"
+					class="mb-2"
+					:rules="[(v) => !!v || 'Password is required']"
+					required
 				/>
 				<v-checkbox
 					label="TLS: Secure"
@@ -101,6 +131,7 @@ function sanitizeAPIRoot(path) {
 						type="submit"
 						color="success"
 						variant="tonal"
+						:disabled="!isValid"
 						>Create Node</v-btn
 					>
 					<v-btn

--- a/src/composables/useConfigPersistence.ts
+++ b/src/composables/useConfigPersistence.ts
@@ -316,7 +316,7 @@ export function useConfigPersistence() {
 
 					for (const serializedNode of loadedNodes) {
 						if (
-							!nodeStore.checkIfNodeExists(serializedNode.name) &&
+							!nodeStore.checkIfNodeNameExists(serializedNode.name) &&
 							!nodeStore.checkIfNodeEndpointExists(
 								serializedNode.host,
 								serializedNode.port

--- a/src/lib/OSHConnectDataStructs.ts
+++ b/src/lib/OSHConnectDataStructs.ts
@@ -204,7 +204,8 @@ export class OSHNode {
 				if (!systemStore?.checkIfSystemExists?.(sys.properties.id)) {
 					const newSys = new OSHSystem(sys, this);
 
-					await Promise.all([
+					//@ts-ignore
+					await Promise.allSettled([
 						newSys.getDataStreams(),
 						newSys.getControlStreams(),
 						newSys.getSamplingFeatures(),

--- a/src/lib/OSHConnectDataStructs.ts
+++ b/src/lib/OSHConnectDataStructs.ts
@@ -13,7 +13,11 @@ import { VisualizationComponents } from '@/lib/VisualizationHelpers';
 import { CONFIG_UID_BASE } from '@/composables/useConfigPersistence';
 import { WizardConfig } from '@/stores/vizwizstore';
 import { ViewLocation } from '@/modules/visualization/registry/types';
-import { showToast } from '@/composables/useToast';
+
+export interface Result {
+	success: boolean;
+	message?: string;
+}
 
 let sharedStores: any = null;
 
@@ -45,21 +49,23 @@ export class OSHConnect {
 		username: string,
 		password: string,
 		tls: boolean = false
-	): Promise<OSHNode | null> {
+	): Promise<OSHNode | Result> {
 		const newNode = new OSHNode(name, host, port, endpoint, username, password, tls, this);
 		const isReachable = await this.checkNodeReachable(newNode);
-		if (!isReachable) {
-			console.error('Failed to connect to node.');
-			return null;
+		const nodeExists = this.checkIfNodeExists(newNode);
+		if (!isReachable.success) {
+			return isReachable;
+		} else if (!nodeExists.success) {
+			return nodeExists;
 		} else {
 			this.nodeStore.addNode(newNode);
 			return newNode;
 		}
 	}
 
-	async checkNodeReachable(newNode: OSHNode) {
-		const endpoint = `${newNode.tls ? 'https' : 'http'}://${newNode.getEndpointUrl()}`;
-		const encoded = btoa(`${newNode.username}:${newNode.password}`);
+	async checkNodeReachable(node: OSHNode): Promise<Result> {
+		const endpoint = `${node.tls ? 'https' : 'http'}://${node.getEndpointUrl()}`;
+		const encoded = btoa(`${node.username}:${node.password}`);
 		const options: RequestInit = {
 			method: 'GET',
 			headers: {
@@ -72,15 +78,31 @@ export class OSHConnect {
 		try {
 			const response = await fetch(endpoint, options);
 			if (response.ok) {
-				return true;
+				return {
+					success: true,
+				};
 			} else {
-				showToast(`Node is not reachable.`, 'ERROR');
-				return false;
+				console.error('Node is not reachable.');
+				return {
+					success: false,
+					message: 'Node is not reachable.',
+				};
 			}
 		} catch (error) {
-			showToast(`Failed to connect to node.`, 'ERROR');
-			return false;
+			console.error('Failed to connect to node:', error);
+			return {
+				success: false,
+				message: 'Failed to connect to node.',
+			};
 		}
+	}
+
+	checkIfNodeExists(node: OSHNode): Result {
+		if (this.nodeStore.checkIfNodeNameExists(node.name))
+			return { success: false, message: 'Node name already exists.' };
+		if (this.nodeStore.checkIfNodeEndpointExists(node.host, node.port))
+			return { success: false, message: 'Node endpoint already exists.' };
+		else return { success: true };
 	}
 
 	// Fetch all resources that are relatively static

--- a/src/lib/OSHConnectDataStructs.ts
+++ b/src/lib/OSHConnectDataStructs.ts
@@ -13,6 +13,7 @@ import { VisualizationComponents } from '@/lib/VisualizationHelpers';
 import { CONFIG_UID_BASE } from '@/composables/useConfigPersistence';
 import { WizardConfig } from '@/stores/vizwizstore';
 import { ViewLocation } from '@/modules/visualization/registry/types';
+import { showToast } from '@/composables/useToast';
 
 let sharedStores: any = null;
 
@@ -36,7 +37,7 @@ export class OSHConnect {
 		this.nodeStore = stores.nodeStore;
 	}
 
-	createNode(
+	async createNode(
 		name: string,
 		host: string,
 		port: string | number,
@@ -44,10 +45,42 @@ export class OSHConnect {
 		username: string,
 		password: string,
 		tls: boolean = false
-	): OSHNode {
+	): Promise<OSHNode | null> {
 		const newNode = new OSHNode(name, host, port, endpoint, username, password, tls, this);
-		this.nodeStore.addNode(newNode);
-		return newNode;
+		const isReachable = await this.checkNodeReachable(newNode);
+		if (!isReachable) {
+			console.error('Failed to connect to node.');
+			return null;
+		} else {
+			this.nodeStore.addNode(newNode);
+			return newNode;
+		}
+	}
+
+	async checkNodeReachable(newNode: OSHNode) {
+		const endpoint = `${newNode.tls ? 'https' : 'http'}://${newNode.getEndpointUrl()}`;
+		const encoded = btoa(`${newNode.username}:${newNode.password}`);
+		const options: RequestInit = {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Basic ${encoded}`,
+			},
+			mode: 'cors',
+		};
+
+		try {
+			const response = await fetch(endpoint, options);
+			if (response.ok) {
+				return true;
+			} else {
+				showToast(`Node is not reachable.`, 'ERROR');
+				return false;
+			}
+		} catch (error) {
+			showToast(`Failed to connect to node.`, 'ERROR');
+			return false;
+		}
 	}
 
 	// Fetch all resources that are relatively static

--- a/src/modules/visualization/components/composables/useVisualizationSidebar.ts
+++ b/src/modules/visualization/components/composables/useVisualizationSidebar.ts
@@ -39,8 +39,6 @@ export function useVisualizationSidebar() {
 	/* Panel state */
 	const openPanels = ref<string[]>([]);
 	function handleOpenPanels() {
-		console.log('Here', openPanels.value);
-
 		if (mapVisualizations.value.length) {
 			if (!openPanels.value.includes('map')) openPanels.value.push('map');
 		} else {

--- a/src/stores/nodestore.ts
+++ b/src/stores/nodestore.ts
@@ -52,17 +52,7 @@ export const useNodeStore = defineStore(
 		};
 
 		const checkIfNodeEndpointExists = (host: string, port: string | number): boolean => {
-			function normalizeHost(host: string): string {
-				let normalized = host.trim().toLowerCase();
-				if (normalized === 'localhost') return '127.0.0.1';
-				return normalized;
-			}
-
-			const currentHost = normalizeHost(host);
-
-			return nodes.value.some((node) => {
-				return normalizeHost(node.host) === currentHost && node.port == port;
-			});
+			return nodes.value.some((node) => node.host === host && node.port == port);
 		};
 
 		const rehydrateNodes = async (oshConnect: OSHConnect): Promise<void> => {

--- a/src/stores/nodestore.ts
+++ b/src/stores/nodestore.ts
@@ -20,7 +20,7 @@ export const useNodeStore = defineStore(
 		const serializedNodes: Ref<SerializeNode[]> = ref([]);
 
 		const addNode = (node: OSHNode): any => {
-			if (checkIfNodeExists(node.name) || node.name === undefined) {
+			if (checkIfNodeNameExists(node.name) || node.name === undefined) {
 				showToast('Node already exists or name is undefined', 'ERROR');
 				return;
 			}
@@ -47,12 +47,22 @@ export const useNodeStore = defineStore(
 			return nodes.value.find((node) => node.name === name);
 		};
 
-		const checkIfNodeExists = (name: string): boolean => {
+		const checkIfNodeNameExists = (name: string): boolean => {
 			return nodes.value.some((node) => node.name === name);
 		};
 
 		const checkIfNodeEndpointExists = (host: string, port: string | number): boolean => {
-			return nodes.value.some((node) => node.host === host && node.port == port);
+			function normalizeHost(host: string): string {
+				let normalized = host.trim().toLowerCase();
+				if (normalized === 'localhost') return '127.0.0.1';
+				return normalized;
+			}
+
+			const currentHost = normalizeHost(host);
+
+			return nodes.value.some((node) => {
+				return normalizeHost(node.host) === currentHost && node.port == port;
+			});
 		};
 
 		const rehydrateNodes = async (oshConnect: OSHConnect): Promise<void> => {
@@ -89,7 +99,7 @@ export const useNodeStore = defineStore(
 			addNode,
 			removeNode,
 			getNodeByName,
-			checkIfNodeExists,
+			checkIfNodeNameExists,
 			checkIfNodeEndpointExists,
 			rehydrateNodes,
 			updateDefaultNode,


### PR DESCRIPTION
- Input validation for fields in node config form
- Check if node exists before adding, error toast if cannot reach
- Prevent duplicate nodes by checking host+port
- Prevent duplicate node names