### PR TITLE
251 make controlstream select optional

### DIFF
--- a/src/modules/visualization/registry/types.ts
+++ b/src/modules/visualization/registry/types.ts
@@ -37,7 +37,8 @@ export type VisualizationBuilderModule = () => void;
  * - description: Short description of the visualization as helper text in the UI
  * - formComponents: Array of form components to render in the visualization wizard
  * - builder: Async function that imports the visualization's Builder.ts, which contains a default export build() to construct the visualization
- * - requireCs: Optional boolean flag to indicate if the visualization requires a controlstream
+ * - supportsCs: Boolean flag to indicate if the visualization can support a controlstream if available
+ * - requireCs: Boolean flag to indicate if the visualization REQUIRES a controlstream
  * - supportedMaps: Optional array of supported map types, if map-related
  */
 export interface VisualizationDescriptor {
@@ -48,6 +49,7 @@ export interface VisualizationDescriptor {
 	description: string;
 	formComponents: VisualizationFormComponent[];
 	builder: () => Promise<{ default: VisualizationBuilderModule }>;
-	requireCs?: boolean; // Optional flag to indicate if the visualization requires a controlstream
+	supportsCs: boolean; // Optional flag to indicate if the visualization can support a controlstream if available
+	requireCs: boolean; // Optional flag to indicate if the visualization requires a controlstream
 	supportedMaps?: ('cesium' | 'leaflet')[]; // If map-related, specify what maps it is supported by
 }

--- a/src/modules/visualization/visualizations/chart/Descriptor.ts
+++ b/src/modules/visualization/visualizations/chart/Descriptor.ts
@@ -27,4 +27,6 @@ export const ChartDescriptor: VisualizationDescriptor = {
 	description: 'Visualize data as a chart.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/chart/Builder'),
+	supportsCs: false,
+	requireCs: false,
 };

--- a/src/modules/visualization/visualizations/ellipse/Descriptor.ts
+++ b/src/modules/visualization/visualizations/ellipse/Descriptor.ts
@@ -27,5 +27,7 @@ export const EllipseDescriptor: VisualizationDescriptor = {
 	description: 'Visualize an ellipse on the map.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/ellipse/Builder'),
+	supportsCs: false,
+	requireCs: false,
 	supportedMaps: ['cesium'],
 };

--- a/src/modules/visualization/visualizations/geoptz/Descriptor.ts
+++ b/src/modules/visualization/visualizations/geoptz/Descriptor.ts
@@ -27,6 +27,7 @@ export const GeoPtzDescriptor: VisualizationDescriptor = {
 	description: 'Task supported sensors with LLA coordinates.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/geoptz/Builder'),
+	supportsCs: true, // This visualization requires a controlstream to function
 	requireCs: true, // This visualization requires a controlstream to function
 	supportedMaps: ['cesium', 'leaflet'],
 };

--- a/src/modules/visualization/visualizations/lob/Descriptor.ts
+++ b/src/modules/visualization/visualizations/lob/Descriptor.ts
@@ -27,5 +27,7 @@ export const LobDescriptor: VisualizationDescriptor = {
 	description: 'Visualize a point marker with a line indicating the line of bearing (LOB).',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/lob/Builder'),
+	supportsCs: false,
+	requireCs: false,
 	supportedMaps: ['cesium', 'leaflet'],
 };

--- a/src/modules/visualization/visualizations/mission/Descriptor.ts
+++ b/src/modules/visualization/visualizations/mission/Descriptor.ts
@@ -27,6 +27,7 @@ export const MissionDescriptor: VisualizationDescriptor = {
 	description: 'Create and manage missions for a drone.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/mission/Builder'),
+	supportsCs: true, // This visualization requires a controlstream to function
 	requireCs: true, // This visualization requires a controlstream to function
 	supportedMaps: ['cesium', 'leaflet'],
 };

--- a/src/modules/visualization/visualizations/pointmarker/Descriptor.ts
+++ b/src/modules/visualization/visualizations/pointmarker/Descriptor.ts
@@ -27,5 +27,7 @@ export const PointMarkerDescriptor: VisualizationDescriptor = {
 	description: 'Visualize a point marker on the map.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/pointmarker/Builder'),
+	supportsCs: false,
+	requireCs: false,
 	supportedMaps: ['cesium', 'leaflet'],
 };

--- a/src/modules/visualization/visualizations/polyline/Descriptor.ts
+++ b/src/modules/visualization/visualizations/polyline/Descriptor.ts
@@ -27,5 +27,7 @@ export const PolylineDescriptor: VisualizationDescriptor = {
 	description: 'Visualize a polyline on the map.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/polyline/Builder'),
+	supportsCs: false,
+	requireCs: false,
 	supportedMaps: ['cesium', 'leaflet'],
 };

--- a/src/modules/visualization/visualizations/sigint/Descriptor.ts
+++ b/src/modules/visualization/visualizations/sigint/Descriptor.ts
@@ -48,5 +48,7 @@ export const SigIntDescriptor: VisualizationDescriptor = {
 		CustomizeComponent,
 	],
 	builder: () => import('@/modules/visualization/visualizations/sigint/Builder'),
+	supportsCs: false,
+	requireCs: false,
 	supportedMaps: ['cesium'],
 };

--- a/src/modules/visualization/visualizations/text/Descriptor.ts
+++ b/src/modules/visualization/visualizations/text/Descriptor.ts
@@ -27,4 +27,6 @@ export const TextDescriptor: VisualizationDescriptor = {
 	description: 'Display selected properties from a datastream.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/text/Builder'),
+	supportsCs: false,
+	requireCs: false,
 };

--- a/src/modules/visualization/visualizations/video/Descriptor.ts
+++ b/src/modules/visualization/visualizations/video/Descriptor.ts
@@ -27,6 +27,8 @@ export const VideoDescriptor: VisualizationDescriptor = {
 	description: 'Display a video stream.',
 	formComponents: [ConfigComponent, CustomizeComponent],
 	builder: () => import('@/modules/visualization/visualizations/video/Builder'),
+	supportsCs: true, // Supports controlstream for PTZ commands if available
+	requireCs: false, // PTZ not required
 };
 
 // Type for PTZ command directions

--- a/src/modules/visualization/wizard/SelectData.vue
+++ b/src/modules/visualization/wizard/SelectData.vue
@@ -8,9 +8,16 @@ import { useControlStreamStore } from '@/stores/controlstreamstore';
 import { VisualizationComponentEmits } from '../registry/VisualizationRegistry';
 import { useComponentValidation } from './composables/useComponentValidation';
 
-const props = defineProps<{
-	requireCs?: boolean;
-}>();
+const props = withDefaults(
+	defineProps<{
+		supportsCs: boolean;
+		requireCs: boolean;
+	}>(),
+	{
+		supportsCs: true,
+		requireCs: false,
+	}
+);
 
 // Stores
 const vizwizStore = useVizWizStore();
@@ -110,6 +117,7 @@ useComponentValidation(valid, emit);
 	></v-autocomplete>
 	<!-- Select for controlstreams -->
 	<v-autocomplete
+		v-if="props.supportsCs"
 		v-model="selectedControlstreams"
 		:items="listControlstreams"
 		hint="Select one or more controlstreams"

--- a/src/modules/visualization/wizard/SelectData.vue
+++ b/src/modules/visualization/wizard/SelectData.vue
@@ -114,6 +114,7 @@ useComponentValidation(valid, emit);
 		clearable
 		validate-on="blur"
 		:rules="[(v: any) => !!v.length || 'At least one datastream must be selected']"
+		:disabled="!selectedSystems.length"
 	></v-autocomplete>
 	<!-- Select for controlstreams -->
 	<v-autocomplete
@@ -134,5 +135,6 @@ useComponentValidation(valid, emit);
 				? [(v: any) => !!v.length || 'At least one controlstream must be selected']
 				: []
 		"
+		:disabled="!selectedSystems.length"
 	></v-autocomplete>
 </template>

--- a/src/modules/visualization/wizard/VisualizationWizard.vue
+++ b/src/modules/visualization/wizard/VisualizationWizard.vue
@@ -56,7 +56,12 @@ onMounted(async () => await init());
 							v-model:valid="componentValid[index]"
 							v-bind="
 								index === 1
-									? { requireCs: VisualizationRegistry[selectedType]?.requireCs }
+									? {
+											supportsCs:
+												VisualizationRegistry[selectedType]?.supportsCs,
+											requireCs:
+												VisualizationRegistry[selectedType]?.requireCs,
+										}
 									: {}
 							"
 						/>


### PR DESCRIPTION
Added `supportsCs` and `requireCs` for visualization descriptors to control whether the "Data" step has a controlstream input, and whether or not the input is required for the visualization if applicable.