### PR TITLE
253 persist map visualization visibility between map toggle

### DIFF
--- a/src/modules/map/adapters/types.ts
+++ b/src/modules/map/adapters/types.ts
@@ -1,4 +1,3 @@
-import { Geometry } from '@/lib/OSHConnectDataStructs';
 import { MapLayer } from './cesium.adapter';
 
 export type MapClickHandler = (lat: number, lon: number, alt: number) => void;
@@ -8,14 +7,6 @@ export type MapPoint = {
 	lon: number;
 	alt: number;
 };
-export const layerTypes = [
-	'layerIdToPolylines',
-	//these are not implemented yet, so u can comment them out tbh but i wouldnt remove them
-	// 'layerIdToEllipsoids',
-	// 'layerIdToPolygon',
-	// 'layerIdToFrustum',
-	// 'layerIdToDrapedImage'
-];
 
 export interface MapAdapter {
 	init(container: string): Promise<void>;

--- a/src/modules/map/composables/useMap.ts
+++ b/src/modules/map/composables/useMap.ts
@@ -2,9 +2,6 @@ import { useMapStore } from '@/stores/mapstore';
 import { useVisualizationStore } from '@/stores/visualizationstore';
 import { computed, onMounted, ref, watch } from 'vue';
 import PointMarkerLayer from 'osh-js/source/core/ui/layer/PointMarkerLayer';
-import LoBLayer from 'osh-js/source/core/ui/layer/viewer/LoB.js';
-import EllipseLayer from 'osh-js/source/core/ui/layer/EllipseLayer';
-import PolylineLayer from 'osh-js/source/core/ui/layer/PolylineLayer';
 import {
 	createFOIProps,
 	createMapVisualizations,
@@ -18,7 +15,7 @@ import { taskGeoPTZ } from '../services/geoPTZ.service';
 import { MapAdapter } from '../adapters/types';
 import { createLeafletAdapter } from '../adapters/leaflet.adapter';
 import { useSettingsStore } from '@/stores/settingsstore';
-import { isMapLayerCompatible } from '@/modules/visualization/registry/VisualizationRegistry';
+import { isMapLayerCompatible, SupportedMapLayer } from '../supportedMapLayers';
 
 export function useMap() {
 	// Stores
@@ -33,9 +30,7 @@ export function useMap() {
 	});
 
 	// Map of visualization ID to its corresponding visualization layer instance
-	const mapItemLayers = ref<
-		Map<string, PointMarkerLayer | LoBLayer | EllipseLayer | PolylineLayer>
-	>(new Map());
+	const mapItemLayers = ref<Map<string, SupportedMapLayer>>(new Map());
 	// List of all connected datasource instances created for map visualizations
 	const listDataSourceInstances = ref<SweApi[]>([]);
 	// Array of waypoint Pointmarkers for mission builder

--- a/src/modules/map/composables/useMap.ts
+++ b/src/modules/map/composables/useMap.ts
@@ -85,6 +85,9 @@ export function useMap() {
 
 		// Delete all FOIs
 		visualizationStore.clearFOILayers();
+
+		// Clear list of hidden visualizations
+		visualizationStore.clearMapLayerVisibility();
 	}
 	watch(mapType, async () => {
 		await switchMap();

--- a/src/modules/map/mapVisualizations.ts
+++ b/src/modules/map/mapVisualizations.ts
@@ -13,13 +13,14 @@ import { useSettingsStore } from '@/stores/settingsstore';
 import { randomUUID } from 'osh-js/source/core/utils/Utils.js';
 import { getLayerId } from './services/layerId.service';
 import { colorHash } from './services/colorId.service';
+import { SupportedMapLayer } from './supportedMapLayers';
 
 // prettier-ignore
 // @ts-ignore
 const iconBase = import.meta.env.VITE_VIEWER_ENDPOINT !== undefined ? import.meta.env.VITE_VIEWER_ENDPOINT : '';
 
 export interface ICreateMapVisualizationResult {
-	vizLayer: PointMarkerLayer | LoBLayer | EllipseLayer | PolylineLayer;
+	vizLayer: SupportedMapLayer;
 	dsInstances: SweApi[];
 }
 
@@ -481,9 +482,9 @@ export function createFOIProps(geometry: Geometry) {
 }
 
 export function rebuildMapVisualizations(
-	oldLayers: Map<string, PointMarkerLayer | LoBLayer | EllipseLayer | PolylineLayer>
-): Map<string, PointMarkerLayer | LoBLayer | EllipseLayer | PolylineLayer> {
-	const newLayers = new Map<string, PointMarkerLayer | LoBLayer | EllipseLayer | PolylineLayer>();
+	oldLayers: Map<string, SupportedMapLayer>
+): Map<string, SupportedMapLayer> {
+	const newLayers = new Map<string, SupportedMapLayer>();
 
 	oldLayers.forEach((layer) => {
 		// Add new PM Layers

--- a/src/modules/map/supportedMapLayers.ts
+++ b/src/modules/map/supportedMapLayers.ts
@@ -1,0 +1,29 @@
+import { useSettingsStore } from '@/stores/settingsstore';
+import {
+	VisualizationRegistry,
+	VisualizationType,
+} from '../visualization/registry/VisualizationRegistry';
+import PointMarkerLayer from 'osh-js/source/core/ui/layer/PointMarkerLayer';
+import LoBLayer from 'osh-js/source/core/ui/layer/viewer/LoB.js';
+import EllipseLayer from 'osh-js/source/core/ui/layer/EllipseLayer';
+import PolylineLayer from 'osh-js/source/core/ui/layer/PolylineLayer';
+
+export const SupportedMapLayers = {
+	PointMarkerLayer: PointMarkerLayer,
+	LoBLayer: LoBLayer,
+	EllipseLayer: EllipseLayer,
+	PolylineLayer: PolylineLayer,
+} as const;
+export type SupportedMapLayer = (typeof SupportedMapLayers)[keyof typeof SupportedMapLayers];
+
+/**
+ * Determine if a visualization type is compatible with the currently focused map
+ * @param type
+ * @returns
+ */
+export function isMapLayerCompatible(type: VisualizationType) {
+	const settingsStore = useSettingsStore();
+	const descriptor = VisualizationRegistry[type];
+	if (!descriptor) return false;
+	return descriptor.supportedMaps?.includes(settingsStore.focusedMap);
+}

--- a/src/modules/visualization/registry/VisualizationRegistry.ts
+++ b/src/modules/visualization/registry/VisualizationRegistry.ts
@@ -7,7 +7,6 @@ import { VideoDescriptor } from '../visualizations/video/Descriptor';
 import { MissionDescriptor } from '@/modules/visualization/visualizations/mission/Descriptor';
 import { VisualizationDescriptor } from './types';
 import { EllipseDescriptor } from '../visualizations/ellipse/Descriptor';
-import { useSettingsStore } from '@/stores/settingsstore';
 import { SigIntDescriptor } from '../visualizations/sigint/Descriptor';
 import { PolylineDescriptor } from '../visualizations/polyline/Descriptor';
 
@@ -36,16 +35,4 @@ export type VisualizationType = keyof typeof VisualizationRegistry;
  */
 export interface VisualizationComponentEmits {
 	(event: 'update:valid', value: boolean): void;
-}
-
-/**
- * Determine if a visualization type is compatible with the currently focused map
- * @param type
- * @returns
- */
-export function isMapLayerCompatible(type: VisualizationType) {
-	const settingsStore = useSettingsStore();
-	const descriptor = VisualizationRegistry[type];
-	if (!descriptor) return false;
-	return descriptor.supportedMaps?.includes(settingsStore.focusedMap);
 }

--- a/src/modules/visualization/sidebar/components/MapVisualizationWrapper.vue
+++ b/src/modules/visualization/sidebar/components/MapVisualizationWrapper.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { OSHVisualization } from '@/lib/OSHConnectDataStructs';
-import { isMapLayerCompatible, VisualizationRegistry } from '../../registry/VisualizationRegistry';
+import { VisualizationRegistry } from '../../registry/VisualizationRegistry';
 import DeleteButton from '@/components/ui/DeleteButton.vue';
 import { computed, ref, watch } from 'vue';
 import { useMapStore } from '@/stores/mapstore';
+import { isMapLayerCompatible } from '@/modules/map/supportedMapLayers';
 
 const {
 	viz,
@@ -36,9 +37,6 @@ function getIcon(viz: OSHVisualization) {
 	const iconName = viz.visualizationComponents.dataLayer.iconName;
 	if (iconName) {
 		if (viz.visualizationComponents.dataLayer.iconOpacity === 0) {
-			console.log(
-				`Visualization ${viz.name} has iconName defined but iconOpacity is set to 0. Defaulting to type icon.`
-			);
 			return VisualizationRegistry[viz.type].icon ?? 'mdi-shape';
 		}
 		return `mdi-${iconName}`;
@@ -58,14 +56,8 @@ function getIconColor(viz: OSHVisualization) {
 		viz.visualizationComponents.dataLayer?.color
 	) {
 		if (viz.visualizationComponents.dataLayer?.iconOpacity === 0) {
-			console.log(
-				`Visualization ${viz.name} has both iconColor and color defined, but iconOpacity is set to 0. Using color for icon display.`
-			);
 			return viz.visualizationComponents.dataLayer.color;
 		}
-		console.log(
-			`Visualization ${viz.name} has both iconColor and color defined. Using iconColor for icon display.`
-		);
 	}
 	// Handle remaining cases, with preference to iconColor
 	return (

--- a/src/modules/visualization/sidebar/composables/useVisualizationSidebar.ts
+++ b/src/modules/visualization/sidebar/composables/useVisualizationSidebar.ts
@@ -3,6 +3,7 @@ import {
 	IEllipseLayerProperties,
 	ILineOfBearingLayerProperties,
 	IPointMarkerLayerProperties,
+	IPolylineLayerProperties,
 	VisualizationLayerProperties,
 } from '@/lib/VisualizationHelpers';
 import { useMapStore } from '@/stores/mapstore';
@@ -71,7 +72,8 @@ export function useVisualizationSidebar() {
 	): layer is
 		| IPointMarkerLayerProperties
 		| ILineOfBearingLayerProperties
-		| IEllipseLayerProperties {
+		| IEllipseLayerProperties
+		| IPolylineLayerProperties {
 		return !!layer && 'iconName' in layer;
 	}
 	function isMapLayerVisible(id: string): boolean {

--- a/src/stores/visualizationstore.ts
+++ b/src/stores/visualizationstore.ts
@@ -68,6 +68,10 @@ export const useVisualizationStore = defineStore(
 			return layerVisibility.value.get(layerId) ?? true;
 		};
 
+		const clearMapLayerVisibility = () => {
+			layerVisibility.value.clear();
+		};
+
 		const rehydrateVisualizations = (): void => {
 			if (serializedVisualizations.value.length === 0 || visualizations.value.length > 0)
 				return;
@@ -104,6 +108,7 @@ export const useVisualizationStore = defineStore(
 			getVisualizationsByType,
 			toggleMapLayerVisibility,
 			isMapLayerVisible,
+			clearMapLayerVisibility,
 			layerVisibility,
 			rehydrateVisualizations,
 			foiLayers,


### PR DESCRIPTION
Temporary fix: reset the visibility state for all map visualizations to be "visible" on map toggle.
There are potential issues related to #234 that should be investigated before resolving this issue.