### PR TITLE
365 cesium tileset z fighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osh-viewer",
-	"version": "3.1.1",
+	"version": "3.2.0-alpha",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osh-viewer",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -40,6 +40,12 @@ export function createCesiumAdapter(): MapAdapter {
 			layers: [],
 			geocoder: Cesium.IonGeocodeProviderType.GOOGLE,
 		});
+		// osh-js's CesiumView forces depthTestAgainstTerrain = true at
+		// construction, even though the map starts on the smooth ellipsoid (no
+		// real terrain). With it on but nothing to occlude, ground-clamped
+		// entities z-fight against the globe surface and flicker from first load.
+		// Turn it off; flip back on only if entities should hide behind terrain.
+		mapView.viewer.scene.globe.depthTestAgainstTerrain = false;
 		// Wait for Cesium to be fully ready
 		await new Promise(requestAnimationFrame);
 	}
@@ -284,12 +290,19 @@ export function createCesiumAdapter(): MapAdapter {
 			googlePhotorealistic = await Cesium.createGooglePhotorealistic3DTileset();
 			viewer.scene.primitives.add(googlePhotorealistic);
 		}
+		// The photorealistic tileset ships its own textured surface mesh. Leaving
+		// the globe (ellipsoid + imagery + terrain) visible underneath makes the
+		// two coplanar surfaces z-fight — the shimmer/splotchy effect from #365.
+		// Hide the globe while photoreal is on; selections underneath are kept.
+		viewer.scene.globe.show = false;
 	}
 
 	function removeGooglePhotorealistic() {
 		if (googlePhotorealistic && mapView.viewer) {
 			mapView.viewer.scene.primitives.remove(googlePhotorealistic);
 			googlePhotorealistic = null;
+			// Restore the globe (and its preserved terrain/imagery selections).
+			mapView.viewer.scene.globe.show = true;
 		}
 	}
 

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -295,6 +295,12 @@ export function createCesiumAdapter(): MapAdapter {
 		// two coplanar surfaces z-fight — the shimmer/splotchy effect from #365.
 		// Hide the globe while photoreal is on; selections underneath are kept.
 		viewer.scene.globe.show = false;
+		// The base layer picker only changes imagery/terrain on the now-hidden
+		// globe, so it's inert while photoreal is on — hide it to avoid the
+		// "clicking does nothing" confusion. Selections are preserved underneath.
+		if (viewer.baseLayerPicker?.container) {
+			viewer.baseLayerPicker.container.style.display = 'none';
+		}
 	}
 
 	function removeGooglePhotorealistic() {
@@ -303,6 +309,10 @@ export function createCesiumAdapter(): MapAdapter {
 			googlePhotorealistic = null;
 			// Restore the globe (and its preserved terrain/imagery selections).
 			mapView.viewer.scene.globe.show = true;
+			// Bring back the base layer picker hidden while photoreal was on.
+			if (mapView.viewer.baseLayerPicker?.container) {
+				mapView.viewer.baseLayerPicker.container.style.display = '';
+			}
 		}
 	}
 

--- a/src/modules/settings/MapSettings.vue
+++ b/src/modules/settings/MapSettings.vue
@@ -119,9 +119,15 @@ const canAddUrl = computed(() => {
 						</v-list-item>
 						<v-list-item>
 							<v-list-item-title>Enable 3D Buildings</v-list-item-title>
+							<v-list-item-subtitle
+								v-if="!enable3DTerrain && !enableGooglePhotorealistic"
+							>
+								Requires 3D terrain or photorealistic tiles
+							</v-list-item-subtitle>
 							<template #append>
 								<v-switch
 									v-model="enable3DBuildings"
+									:disabled="!enable3DTerrain && !enableGooglePhotorealistic"
 									color="primary"
 									inset="material"
 									hide-details

--- a/src/stores/settingsstore.ts
+++ b/src/stores/settingsstore.ts
@@ -47,17 +47,38 @@ export const useSettingsStore = defineStore(
 			geoPtzIconColor.value = value;
 		}
 
+		// Buildings need a surface to sit on (terrain or photorealistic tiles).
+		// With neither on there's nothing to place them on, so force them off.
+		// The UI also greys out the buildings toggle in that state.
+		function syncBuildingsToSurface() {
+			if (!enable3DTerrain.value && !enableGooglePhotorealistic.value) {
+				enable3DBuildings.value = false;
+			}
+		}
 		function set3DTerrain(value: boolean | null) {
 			if (value === null) return;
 			enable3DTerrain.value = value;
+			// Terrain and photorealistic tiles are mutually exclusive surfaces (#365).
+			if (value) enableGooglePhotorealistic.value = false;
+			syncBuildingsToSurface();
 		}
 		function set3DBuildings(value: boolean | null) {
 			if (value === null) return;
 			enable3DBuildings.value = value;
+			// Buildings need a surface. If photorealistic tiles aren't already
+			// providing one, force terrain on so buildings don't float above the
+			// ellipsoid (#365). When photorealistic IS on, leave it — buildings can
+			// overlay it, which helps in areas where the photoreal mesh has artifacts.
+			if (value && !enableGooglePhotorealistic.value) {
+				enable3DTerrain.value = true;
+			}
 		}
 		function setGooglePhotorealistic(value: boolean | null) {
 			if (value === null) return;
 			enableGooglePhotorealistic.value = value;
+			// Photorealistic tiles and terrain are mutually exclusive surfaces (#365).
+			if (value) enable3DTerrain.value = false;
+			syncBuildingsToSurface();
 		}
 
 		return {


### PR DESCRIPTION
Fixes the splotchy/shimmery globe at app launch.

Also disables the layer picker when photorealistic tiles are on as they take over that function.

Small UI behavior tweak to force 3D buildings to be on only when  either 3D Terrain or Google Photorealistic Tiles are enabled.

Closes #365 