### PR TITLE
370 revert mission waypoints path to geometry

### DIFF
--- a/src/components/ui/MapPointCollectionEditor.vue
+++ b/src/components/ui/MapPointCollectionEditor.vue
@@ -2,6 +2,7 @@
 import { VueDraggable } from 'vue-draggable-plus';
 import { MapPoint } from '@/modules/map/types';
 import { ref } from 'vue';
+import DeleteButton from "@/components/ui/DeleteButton.vue";
 
 const props = withDefaults(
 	defineProps<{
@@ -127,21 +128,10 @@ function clearPoints() {
 				</v-row>
 			</v-list-item-title>
 			<template v-slot:append>
-				<div class="">
-					<v-btn
-						icon
-						size="x-small"
-						variant="text"
-						@click="removePoint(index)"
-					>
-						<v-icon size="small">mdi-close-circle</v-icon>
-						<v-tooltip
-							activator="parent"
-							location="top"
-							>Remove point</v-tooltip
-						>
-					</v-btn>
-				</div>
+          <DeleteButton
+              label="Remove point"
+              @delete="removePoint(index)"
+          ></DeleteButton>
 			</template>
 		</v-list-item>
 	</VueDraggable>

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -265,7 +265,7 @@ export function createCesiumAdapter(): MapAdapter {
 			const entity = drawPoint(
 				wp,
 				'/icons/waypoint/round-pin.png',
-				'#00FF00',
+				'#4c89e7',
 				`WP ${index + 1}`,
 			);
 			mapView.viewer.entities.add(entity);

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -159,6 +159,16 @@ export function createCesiumAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
+	function addMarker(marker: any) {
+		mapView.viewer.entities.add(marker);
+		invalidate();
+	}
+
+	function removeMarker(marker: any) {
+		mapView.viewer.entities.remove(marker);
+		invalidate();
+	}
+
 	async function drawPoint(
         point: MapPoint,
         icon?: string,
@@ -579,6 +589,8 @@ export function createCesiumAdapter(): MapAdapter {
 		onMouseMove,
 		flyToPoint,
 		updateMarker,
+		addMarker,
+		removeMarker,
 		drawPoint,
 		drawCircle,
 		drawPolyline,

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -5,6 +5,8 @@ import { Ion } from 'cesium';
 import { CursorMode, MapPoint, MapPointHandler } from '@/modules/map/types';
 import { GeoOverlay } from '@/modules/map/geo-overlay/types';
 import { randomUUID } from 'osh-js/source/core/utils/Utils.js';
+import { getColoredIconUrl } from '@/modules/map/services/colorId.service';
+import { ICON_BASE } from '@/lib/icons';
 
 // Showcase examples token :P
 // Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ODY0NTkzNS02NzI0LTQwNDktODk4Zi0zZDJjOWI2NTdmYTMiLCJpZCI6MTA1NzQsInNjb3BlcyI6WyJhc3IiLCJnYyJdLCJpYXQiOjE1NTY4NzI1ODJ9.IbAajOLYnsoyKy1BOd7fY1p6GH-wwNVMdMduA2IzGjA';
@@ -157,30 +159,36 @@ export function createCesiumAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
-	function drawPoint(
+	async function drawPoint(
         point: MapPoint,
         icon?: string,
         iconColor?: string,
         label?: string,
         id?: string
     ) {
+		const coloredIcon = iconColor && icon
+			? await getColoredIconUrl(`${ICON_BASE}${icon}`, iconColor)
+			: icon;
 		return new Cesium.Entity({
 			id: id ?? randomUUID(),
 			position: Cesium.Cartesian3.fromDegrees(point.lon, point.lat, point.alt || 0),
 			billboard: {
-				image: icon ?? '/icons/waypoint/round-pin.png',
+                image: coloredIcon ?? '/icons/waypoint/round-pin.png',
 				width:  32,
-				height:  32,
-				color: Cesium.Color.fromCssColorString(iconColor ?? '#FFFFFF'),
+				height:  32
 			},
-            label: {
-                text: label,
-                font: '14pt monospace',
-                style: Cesium.LabelStyle.FILL_AND_OUTLINE,
-                outlineWidth: 2,
-                verticalOrigin: Cesium.VerticalOrigin.TOP,
-                pixelOffset: new Cesium.Cartesian2(0, 32),
-            },
+			...(label
+				? {
+						label: {
+							text: label,
+							font: '14pt monospace',
+							style: Cesium.LabelStyle.FILL_AND_OUTLINE,
+							outlineWidth: 2,
+							verticalOrigin: Cesium.VerticalOrigin.TOP,
+							pixelOffset: new Cesium.Cartesian2(0, 32),
+						},
+					}
+				: {}),
 		});
 	}
 	function drawCircle(
@@ -246,7 +254,7 @@ export function createCesiumAdapter(): MapAdapter {
 	}
 
 	function drawMissionPath(waypoints: MapPoint[]) {
-		const entity = drawPolyline(waypoints, '#FF0000');
+		const entity = drawPolyline(waypoints, '#5d6cce');
 		mapView.viewer.entities.add(entity);
 		flightPathPolylines.push(entity);
 	}
@@ -259,18 +267,18 @@ export function createCesiumAdapter(): MapAdapter {
 		flightPathPolylines = [];
 	}
 
-	function drawMissionWaypoints(waypoints: MapPoint[]) {
+	async function drawMissionWaypoints(waypoints: MapPoint[]) {
 		clearMissionWaypoints();
-		waypoints.forEach((wp, index) => {
-			const entity = drawPoint(
-				wp,
+		for (let index = 0; index < waypoints.length; index++) {
+			const entity = await drawPoint(
+				waypoints[index],
 				'/icons/waypoint/round-pin.png',
-				'#4c89e7',
+				'#5d6cce',
 				`WP ${index + 1}`,
 			);
 			mapView.viewer.entities.add(entity);
 			waypointEntities.push(entity);
-		});
+		}
 		invalidate();
 	}
 

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -262,12 +262,12 @@ export function createCesiumAdapter(): MapAdapter {
 	function drawMissionWaypoints(waypoints: MapPoint[]) {
 		clearMissionWaypoints();
 		waypoints.forEach((wp, index) => {
-			const entity = drawPoint(wp, {
-				label: `WP ${index + 1}`,
-				iconUrl: '/icons/waypoint/round-pin.png',
-				iconColor: '#00FF00',
-				iconSize: [32, 32],
-			});
+			const entity = drawPoint(
+				wp,
+				'/icons/waypoint/round-pin.png',
+				'#00FF00',
+				`WP ${index + 1}`,
+			);
 			mapView.viewer.entities.add(entity);
 			waypointEntities.push(entity);
 		});

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -156,7 +156,32 @@ export function createCesiumAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
-	function drawPoint(point: MapPoint) {}
+	function drawPoint(
+        point: MapPoint,
+        icon?: string,
+        iconColor?: string,
+        label?: string,
+        id?: string
+    ) {
+		return new Cesium.Entity({
+			id: id ?? randomUUID(),
+			position: Cesium.Cartesian3.fromDegrees(point.lon, point.lat, point.alt || 0),
+			billboard: {
+				image: icon ?? '/icons/waypoint/round-pin.png',
+				width:  32,
+				height:  32,
+				color: Cesium.Color.fromCssColorString(iconColor ?? '#FFFFFF'),
+			},
+            label: {
+                text: label,
+                font: '14pt monospace',
+                style: Cesium.LabelStyle.FILL_AND_OUTLINE,
+                outlineWidth: 2,
+                verticalOrigin: Cesium.VerticalOrigin.TOP,
+                pixelOffset: new Cesium.Cartesian2(0, 32),
+            },
+		});
+	}
 	function drawCircle(
 		center: MapPoint,
 		radius: number,

--- a/src/modules/map/adapters/cesium.adapter.ts
+++ b/src/modules/map/adapters/cesium.adapter.ts
@@ -29,6 +29,7 @@ export function createCesiumAdapter(): MapAdapter {
 	let buildingsTileset: any = null;
 	let googlePhotorealistic: any = null;
 	let flightPathPolylines: any[] = [];
+	let waypointEntities: any[] = [];
 
 	/* GeoOverlays */
 	let previewEntity: any = null;
@@ -245,23 +246,11 @@ export function createCesiumAdapter(): MapAdapter {
 	}
 
 	function drawMissionPath(waypoints: MapPoint[]) {
-		const positions = waypoints.map((wp: MapPoint) => {
-			return Cesium.Cartesian3.fromDegrees(wp.lon, wp.lat, wp.alt || 0);
-		});
-		const entity = mapView.viewer.entities.add({
-			polyline: {
-				positions: positions,
-				width: 5,
-				material: new Cesium.PolylineOutlineMaterialProperty({
-					color: Cesium.Color.RED,
-					outlineWidth: 2,
-					outlineColor: Cesium.Color.BLACK,
-				}),
-				clampToGround: true,
-			},
-		});
+		const entity = drawPolyline(waypoints, '#FF0000');
+		mapView.viewer.entities.add(entity);
 		flightPathPolylines.push(entity);
 	}
+
 	function clearMissionPath() {
 		if (!mapView) return;
 		for (const entity of flightPathPolylines) {
@@ -270,6 +259,28 @@ export function createCesiumAdapter(): MapAdapter {
 		flightPathPolylines = [];
 	}
 
+	function drawMissionWaypoints(waypoints: MapPoint[]) {
+		clearMissionWaypoints();
+		waypoints.forEach((wp, index) => {
+			const entity = drawPoint(wp, {
+				label: `WP ${index + 1}`,
+				iconUrl: '/icons/waypoint/round-pin.png',
+				iconColor: '#00FF00',
+				iconSize: [32, 32],
+			});
+			mapView.viewer.entities.add(entity);
+			waypointEntities.push(entity);
+		});
+		invalidate();
+	}
+
+	function clearMissionWaypoints() {
+		if (!mapView) return;
+		for (const entity of waypointEntities) {
+			mapView.viewer.entities.remove(entity);
+		}
+		waypointEntities = [];
+	}
 	async function addTerrain() {
 		// Assign terrain provider to map
 		if (!terrainProvider) {
@@ -564,6 +575,8 @@ export function createCesiumAdapter(): MapAdapter {
 		drawCircle,
 		drawPolyline,
 		drawPolygon,
+		drawMissionWaypoints,
+		clearMissionWaypoints,
 		drawMissionPath,
 		clearMissionPath,
 		addTerrain,

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -143,7 +143,7 @@ export function createLeafletAdapter(): MapAdapter {
 			const marker = drawPoint(
 				wp,
 				'/icons/waypoint/round-pin.png',
-				'#00FF00',
+				'#4c89e7',
 				`WP ${index + 1}`,
 			);
 			marker.addTo(mapView.map);

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -67,6 +67,14 @@ export function createLeafletAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
+	function addMarker(marker: any) {
+		marker.addTo(mapView.map);
+	}
+
+	function removeMarker(marker: any) {
+		mapView.map.removeLayer(marker);
+	}
+
     async function drawPoint(
         point: MapPoint,
         icon?: string,
@@ -279,6 +287,8 @@ export function createLeafletAdapter(): MapAdapter {
 		onMouseMove,
 		flyToPoint,
 		updateMarker,
+		addMarker,
+		removeMarker,
 		drawPoint,
 		drawCircle,
 		drawPolyline,

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -7,6 +7,7 @@ import { GeoOverlay } from '@/modules/map/geo-overlay/types';
 export function createLeafletAdapter(): MapAdapter {
 	let mapView: typeof LeafletView | null;
 	let flightPathPolylines: any[] = [];
+	let waypointMarkers: any[] = [];
 
 	/* GeoOverlays */
 	let previewEntity: any = null;
@@ -124,11 +125,8 @@ export function createLeafletAdapter(): MapAdapter {
 	}
 
 	function drawMissionPath(waypoints: MapPoint[]) {
-		const latLngs = waypoints.map((wp: MapPoint) => [wp.lat, wp.lon]);
-		const polyline = L.polyline(latLngs, {
-			color: 'red',
-			weight: 5,
-		}).addTo(mapView.map);
+		const polyline = drawPolyline(waypoints, '#FF0000');
+		polyline.addTo(mapView.map);
 		flightPathPolylines.push(polyline);
 	}
 
@@ -137,6 +135,27 @@ export function createLeafletAdapter(): MapAdapter {
 			mapView.map.removeLayer(polyline);
 		}
 		flightPathPolylines = [];
+	}
+
+	function drawMissionWaypoints(waypoints: MapPoint[]) {
+		clearMissionWaypoints();
+		waypoints.forEach((wp, index) => {
+			const marker = drawPoint(wp, {
+				label: `WP ${index + 1}`,
+				iconUrl: '/icons/waypoint/round-pin.png',
+				iconColor: '#00FF00',
+				iconSize: [32, 32],
+			});
+			marker.addTo(mapView.map);
+			waypointMarkers.push(marker);
+		});
+	}
+
+	function clearMissionWaypoints() {
+		for (const marker of waypointMarkers) {
+			mapView.map.removeLayer(marker);
+		}
+		waypointMarkers = [];
 	}
 
 	/* Geofence Drawing Tools */
@@ -259,6 +278,8 @@ export function createLeafletAdapter(): MapAdapter {
 		drawCircle,
 		drawPolyline,
 		drawPolygon,
+		drawMissionWaypoints,
+		clearMissionWaypoints,
 		drawMissionPath,
 		clearMissionPath,
 		updateCirclePreview,

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -64,7 +64,25 @@ export function createLeafletAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
-	function drawPoint(point: MapPoint): L.point {}
+    function drawPoint(
+        point: MapPoint,
+        icon?: string,
+        iconColor?: string,
+        label?: string,
+        id?: string
+    ) {
+		const iconOptions: any = {
+			iconUrl: icon ?? '/icons/waypoint/round-pin.png',
+			iconSize: [32, 32],
+		};
+		const marker = L.marker([point.lat, point.lon], {
+			icon: L.icon(iconOptions),
+		});
+		if (label) {
+			marker.bindTooltip(label);
+		}
+		return marker;
+	}
 	function drawCircle(
 		center: MapPoint,
 		radius: number,

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -3,6 +3,8 @@ import L from 'leaflet';
 import { MapAdapter } from './types';
 import { MapPoint, MapPointHandler } from '@/modules/map/types';
 import { GeoOverlay } from '@/modules/map/geo-overlay/types';
+import {getColoredIconUrl} from "@/modules/map/services/colorId.service";
+import {ICON_BASE} from "@/lib/icons";
 
 export function createLeafletAdapter(): MapAdapter {
 	let mapView: typeof LeafletView | null;
@@ -65,15 +67,18 @@ export function createLeafletAdapter(): MapAdapter {
 		mapView.updateMarker(props);
 	}
 
-    function drawPoint(
+    async function drawPoint(
         point: MapPoint,
         icon?: string,
         iconColor?: string,
         label?: string,
         id?: string
     ) {
+		const coloredIcon = iconColor && icon
+			? await getColoredIconUrl(`${ICON_BASE}${icon}`, iconColor)
+			: icon;
 		const iconOptions: any = {
-			iconUrl: icon ?? '/icons/waypoint/round-pin.png',
+			iconUrl: coloredIcon ?? '/icons/waypoint/round-pin.png',
 			iconSize: [32, 32],
 		};
 		const marker = L.marker([point.lat, point.lon], {
@@ -125,7 +130,7 @@ export function createLeafletAdapter(): MapAdapter {
 	}
 
 	function drawMissionPath(waypoints: MapPoint[]) {
-		const polyline = drawPolyline(waypoints, '#FF0000');
+		const polyline = drawPolyline(waypoints, '#5d6cce');
 		polyline.addTo(mapView.map);
 		flightPathPolylines.push(polyline);
 	}
@@ -137,18 +142,18 @@ export function createLeafletAdapter(): MapAdapter {
 		flightPathPolylines = [];
 	}
 
-	function drawMissionWaypoints(waypoints: MapPoint[]) {
+	async function drawMissionWaypoints(waypoints: MapPoint[]) {
 		clearMissionWaypoints();
-		waypoints.forEach((wp, index) => {
-			const marker = drawPoint(
-				wp,
+		for (let index = 0; index < waypoints.length; index++) {
+			const marker = await drawPoint(
+				waypoints[index],
 				'/icons/waypoint/round-pin.png',
-				'#4c89e7',
+				'#5d6cce',
 				`WP ${index + 1}`,
 			);
 			marker.addTo(mapView.map);
 			waypointMarkers.push(marker);
-		});
+		}
 	}
 
 	function clearMissionWaypoints() {

--- a/src/modules/map/adapters/leaflet.adapter.ts
+++ b/src/modules/map/adapters/leaflet.adapter.ts
@@ -140,12 +140,12 @@ export function createLeafletAdapter(): MapAdapter {
 	function drawMissionWaypoints(waypoints: MapPoint[]) {
 		clearMissionWaypoints();
 		waypoints.forEach((wp, index) => {
-			const marker = drawPoint(wp, {
-				label: `WP ${index + 1}`,
-				iconUrl: '/icons/waypoint/round-pin.png',
-				iconColor: '#00FF00',
-				iconSize: [32, 32],
-			});
+			const marker = drawPoint(
+				wp,
+				'/icons/waypoint/round-pin.png',
+				'#00FF00',
+				`WP ${index + 1}`,
+			);
 			marker.addTo(mapView.map);
 			waypointMarkers.push(marker);
 		});

--- a/src/modules/map/adapters/types.ts
+++ b/src/modules/map/adapters/types.ts
@@ -34,6 +34,8 @@ export interface MapAdapter {
 	drawPolygon(points: MapPoint[], borderColor: string | null, fillColor: string | null): any;
 
 	/* Mission Builder */
+	drawMissionWaypoints(waypoints: MapPoint[]): void;
+	clearMissionWaypoints(): void;
 	drawMissionPath(waypoints: MapPoint[]): void;
 	clearMissionPath(): void;
 

--- a/src/modules/map/adapters/types.ts
+++ b/src/modules/map/adapters/types.ts
@@ -17,7 +17,13 @@ export interface MapAdapter {
 	updateMarker(props: any): void;
 
 	/* Map Drawing */
-	drawPoint(point: MapPoint): any;
+	drawPoint(
+        point: MapPoint,
+        icon?: string,
+        iconColor?: string,
+        label?: string,
+        id?: string
+    ): any;
 	drawCircle(
 		center: MapPoint,
 		radius: number,

--- a/src/modules/map/adapters/types.ts
+++ b/src/modules/map/adapters/types.ts
@@ -17,6 +17,8 @@ export interface MapAdapter {
 	updateMarker(props: any): void;
 
 	/* Map Drawing */
+	addMarker(marker: any): void;
+	removeMarker(marker: any): void;
 	drawPoint(
         point: MapPoint,
         icon?: string,

--- a/src/modules/map/composables/useMap.ts
+++ b/src/modules/map/composables/useMap.ts
@@ -69,8 +69,8 @@ export function useMap() {
 	// GEOPTZ
 	const geoPtzLayer = ref<typeof PointMarkerLayer | null>(null);
 	// MISSION BUILDER
-	const driveLocationLayer = ref<typeof PointMarkerLayer | null>(null);
-	const homeLocationLayer = ref<typeof PointMarkerLayer | null>(null);
+	const driveLocationLayer = ref(null);
+	const homeLocationLayer = ref(null);
 	// FOI
 	const foiLayers = ref<{ layer: typeof PointMarkerLayer; props: any }[]>([]);
 
@@ -604,20 +604,22 @@ export function useMap() {
 
 	/* DRIVE LOCATION */
 	async function addDriveLocationLayer(lon: number, lat: number) {
-		const result = await createLocationLayer(
-			{ lon, lat, alt: 0 },
-			'driveLocation',
-			'Drive to Location'
-		);
-		if (result) {
-			removeDriveLocationLayer();
-			driveLocationLayer.value = result.layer;
-			mapAdapter.value?.addLayer(driveLocationLayer.value);
-			if (result.props) mapAdapter.value?.updateMarker(result.props);
-		}
+        if (!mapAdapter.value) return;
+        removeDriveLocationLayer();
+
+        const marker = await mapAdapter.value.drawPoint(
+            { lon, lat, alt: 0 },
+            "/icons/waypoint/round-pin.png",
+            "#00BFFF",
+            "Drive to Location"
+        )
+
+        mapAdapter.value.addMarker(marker);
+        driveLocationLayer.value = marker;
 	}
+
 	function removeDriveLocationLayer() {
-		if (driveLocationLayer.value) mapAdapter.value?.removeLayer(driveLocationLayer.value);
+		if (driveLocationLayer.value) mapAdapter.value?.removeMarker(driveLocationLayer.value);
 		driveLocationLayer.value = null;
 	}
 	watch(
@@ -630,20 +632,21 @@ export function useMap() {
 	/* HOME LOCATION */
 	async function addHomeLocationLayer(lon: number, lat: number) {
 		if (!mapAdapter.value) return;
-		const result = await createLocationLayer(
-			{ lon, lat, alt: 0 },
-			'homeLocation',
-			'Home Location'
-		);
-		if (result) {
-			removeHomeLocationLayer();
-			homeLocationLayer.value = result.layer;
-			mapAdapter.value?.addLayer(homeLocationLayer.value);
-			if (result.props) mapAdapter.value?.updateMarker(result.props);
-		}
-	}
+
+        removeHomeLocationLayer();
+
+        const marker = await mapAdapter.value.drawPoint(
+            { lon, lat, alt: 0 },
+            "/icons/waypoint/home-map-marker.png",
+            "#bd1616",
+            "Home Location"
+        )
+
+        mapAdapter.value.addMarker(marker);
+        homeLocationLayer.value = marker;
+    }
 	function removeHomeLocationLayer() {
-		if (homeLocationLayer.value) mapAdapter.value?.removeLayer(homeLocationLayer.value);
+		if (homeLocationLayer.value) mapAdapter.value?.removeMarker(homeLocationLayer.value);
 		homeLocationLayer.value = null;
 	}
 	watch(

--- a/src/modules/map/composables/useMap.ts
+++ b/src/modules/map/composables/useMap.ts
@@ -7,7 +7,6 @@ import {
 	createGeoPTZLayer,
 	createLocationLayer,
 	createMapVisualizations,
-	createWaypointLayer,
 	rebuildMapVisualizations,
 } from '../mapVisualizations';
 import { OSHVisualization } from '@/lib/OSHConnectDataStructs';
@@ -72,7 +71,6 @@ export function useMap() {
 	// MISSION BUILDER
 	const driveLocationLayer = ref<typeof PointMarkerLayer | null>(null);
 	const homeLocationLayer = ref<typeof PointMarkerLayer | null>(null);
-	const waypointLayers = ref<(typeof PointMarkerLayer)[]>([]); // Array of waypoint Pointmarkers for mission builder
 	// FOI
 	const foiLayers = ref<{ layer: typeof PointMarkerLayer; props: any }[]>([]);
 
@@ -133,13 +131,8 @@ export function useMap() {
 		rebuildGeoOverlayLayers(); // Rebuild GeoOverlays
 
 		// Rebuild all waypoints per system
-		waypointLayers.value = [];
-		let idx = 0;
 		for (const [, systemWaypoints] of missionStore.missionWaypointsPerSystem) {
-			for (const waypoint of systemWaypoints) {
-				await addWaypointLayer(waypoint, idx);
-				idx++;
-			}
+			mapAdapter.value?.drawMissionWaypoints(systemWaypoints);
 			drawMissionPath(systemWaypoints);
 		}
 		if (driveLocationLayer.value && mapStore.currentLLA) {
@@ -663,34 +656,17 @@ export function useMap() {
 	/* MISSION BUILDER */
 	watch(
 		() => missionStore.missionWaypoints,
-		async (waypoints) => {
+		(waypoints) => {
 			if (!mapAdapter.value) return;
 
-			// Remove waypoints
 			clearMission();
 
-			let idx = 0;
 			for (const [, systemWaypoints] of missionStore.missionWaypointsPerSystem) {
-				// Add waypoints
-				for (const waypoint of systemWaypoints) {
-					await addWaypointLayer(waypoint, idx);
-					idx++;
-				}
-                // Draw mission path
-                drawMissionPath(systemWaypoints)
-            }
+				mapAdapter.value.drawMissionWaypoints(systemWaypoints);
+				drawMissionPath(systemWaypoints);
+			}
 		}
 	);
-	async function addWaypointLayer(waypoint: MapPoint, index: number) {
-		if (!mapAdapter.value) return;
-
-		const result = await createWaypointLayer(waypoint, index.toString());
-		if (result) {
-			mapAdapter.value?.addLayer(result.layer);
-			waypointLayers.value.push(result.layer);
-			if (result.props) mapAdapter.value?.updateMarker(result.props);
-		}
-	}
 	function drawMissionPath(waypoints: MapPoint[]) {
 		if (!mapAdapter.value) return;
 
@@ -700,11 +676,7 @@ export function useMap() {
 		}
 	}
 	function clearMission() {
-		for (const layer of waypointLayers.value) {
-			mapAdapter.value?.removeLayer(layer);
-		}
-		waypointLayers.value = [];
-
+		mapAdapter.value?.clearMissionWaypoints();
 		mapAdapter.value?.clearMissionPath();
 	}
 

--- a/src/modules/map/mapVisualizations.ts
+++ b/src/modules/map/mapVisualizations.ts
@@ -558,39 +558,6 @@ export async function createLocationLayer(
 
 	return { layer: locationLayer, props };
 }
-
-export async function createWaypointLayer(
-	waypoint: MapPoint,
-	index: string
-): Promise<{
-	layer: typeof PointMarkerLayer;
-	props: any;
-}> {
-	const icon = await getColoredIconUrl(`${ICON_BASE}/icons/waypoint/round-pin.png`, 'green');
-
-	const waypointLayer = new PointMarkerLayer({
-		id: `waypoint-${index}`,
-		name: `Waypoint ${index + 1}`,
-		location: {
-			x: waypoint.lon,
-			y: waypoint.lat,
-			z: waypoint.alt || (await getGroundAltitude(waypoint.lon, waypoint.lat)),
-		},
-		icon,
-		iconSize: [32, 32],
-		iconAnchor: [16, 32],
-		label: `WP ${index + 1}`,
-		labelColor: '#FFFFFF',
-		labelOutlineColor: '#000000',
-		labelSize: 14,
-		labelOffset: [0, -36],
-		defaultToTerrainElevation: true,
-	});
-
-	const props = await setWaypointData(waypointLayer);
-
-	return { layer: waypointLayer, props };
-}
 export async function createFOILayer(foiLayer: FoiLayer) {
 	const lon = Array.isArray(foiLayer.geometry.coordinates[0])
 		? foiLayer.geometry.coordinates[0][0]

--- a/src/modules/visualization/visualizations/mission/MissionWaypointBuilder.vue
+++ b/src/modules/visualization/visualizations/mission/MissionWaypointBuilder.vue
@@ -2,10 +2,9 @@
 import {computed, ref, watch} from 'vue';
 // @ts-ignore
 import {randomUUID} from 'osh-js/source/core/utils/Utils.js';
-import {VueDraggable} from 'vue-draggable-plus';
 import type {Waypoint} from './types';
 import MapPointEditor from "@/components/ui/MapPointEditor.vue";
-import DeleteButton from "@/components/ui/DeleteButton.vue";
+import MapPointCollectionEditor from "@/components/ui/MapPointCollectionEditor.vue";
 import {useMapStore} from "@/stores/mapstore";
 import {useMapInteractionStore} from "@/stores/mapinteractionstore";
 import type {MapPoint} from "@/modules/map/types";
@@ -29,7 +28,6 @@ const cruiseSpeed = defineModel<number>('cruiseSpeed', { required: true });
 const hoverSpeed = defineModel<number>('hoverSpeed', { required: true });
 const altitudeMode = defineModel<number>('altitudeMode', { required: true });
 const editorPoint = ref<MapPoint>({ lat: 0, lon: 0, alt: 0 });
-const showClearConfirm = ref(false);
 
 const altitudeModeOptions = [
   { title: 'Relative', value: 0},
@@ -49,15 +47,14 @@ function addWaypointFromMap(payload: MapPoint) {
   waypoints.value.push(newWaypoint);
 }
 
-function removeWaypoint(id: string) {
-	waypoints.value = waypoints.value.filter((wp) => wp.id !== id);
-}
-
-function clearAll() {
-	waypoints.value = [];
-	showClearConfirm.value = false;
-	emit('clearWaypoints');
-}
+watch(
+    () => waypoints.value.length,
+    (newLen, oldLen) => {
+      if (newLen === 0 && oldLen > 0) {
+        emit('clearWaypoints');
+      }
+    }
+);
 
 function setLatLonAlt(lat: number, lon: number, alt: number) {
 	editorPoint.value = { lat, lon, alt };
@@ -99,119 +96,11 @@ defineExpose({ setLatLonAlt });
     />
   </div>
 
-  <div class="d-flex justify-space-between align-center mb-2" v-if="waypoints.length > 0">
-    <span class="text-subtitle-2">Waypoints</span>
-    <v-btn
-        :disabled="waypoints.length === 0"
-        color="error"
-        size="small"
-        variant="text"
-        @click="showClearConfirm = true"
-    >
-      Clear current mission
-    </v-btn>
-    <v-dialog
-        v-model="showClearConfirm"
-        max-width="400"
-    >
-      <v-card>
-        <v-card-item>
-          <v-card-title>Clear All Waypoints</v-card-title>
-        </v-card-item>
-        <v-card-text>
-          Are you sure you want to clear all
-          {{ waypoints.length }} waypoints? This action cannot be undone.
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer/>
-          <v-btn
-              variant="text"
-              @click="showClearConfirm = false"
-          >Cancel
-          </v-btn>
-          <v-btn
-              color="error"
-              variant="flat"
-              @click="clearAll"
-          >Clear
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
-  <VueDraggable
-      v-if="waypoints.length > 0"
+  <MapPointCollectionEditor
       v-model="waypoints"
-      :animation="150"
-      class="waypoints-list"
-      handle=".drag-handle"
-  >
-    <v-list-item
-        v-for="(wp, index) in waypoints"
-        :key="wp.id"
-        class="pa-1"
-    >
-      <template v-slot:prepend>
-        <div>
-          <v-icon
-              class="drag-handle mr-1"
-              size="small"
-          >mdi-drag
-          </v-icon>
-          <span class="text-caption w-auto">{{ index + 1 }}.</span>
-        </div>
-      </template>
-      <v-list-item-title class="px-2">
-        <v-row
-            class="align-center"
-            density="compact"
-        >
-          <v-col :cols="isGroundVehicle ? 6 : 4">
-            <v-text-field
-                v-model.number="wp.lat"
-                density="compact"
-                hide-details
-                label="Lat"
-                type="number"
-            />
-          </v-col>
-          <v-col :cols="isGroundVehicle ? 6 : 4">
-            <v-text-field
-                v-model.number="wp.lon"
-                density="compact"
-                hide-details
-                label="Lon"
-                type="number"
-            />
-          </v-col>
-          <v-col
-              v-if="!isGroundVehicle"
-              cols="4"
-          >
-            <v-text-field
-                v-model.number="wp.alt"
-                density="compact"
-                hide-details
-                label="Alt"
-                type="number"
-            />
-          </v-col>
-        </v-row>
-      </v-list-item-title>
-      <template v-slot:append>
-        <DeleteButton
-            label="Remove"
-            @delete="removeWaypoint(wp.id)"
-        ></DeleteButton>
-      </template>
-    </v-list-item>
-  </VueDraggable>
-  <div
-      v-else
-      class="text-caption text-grey text-center pa-4"
-  >
-    No waypoints added. Click on the map or use the form above.
-  </div>
+      title="Waypoints"
+      :hide-alt="isGroundVehicle"
+  />
 
   <v-divider class="mt-4 mb-3" />
 
@@ -267,16 +156,3 @@ defineExpose({ setLatLonAlt });
     </v-col>
   </v-row>
 </template>
-
-<style scoped>
-.waypoints-list {
-	max-height: 175px;
-	overflow-y: auto;
-}
-.drag-handle {
-	cursor: grab;
-}
-.drag-handle:active {
-	cursor: grabbing;
-}
-</style>


### PR DESCRIPTION
Update to use generic map drawing functions
- removed createWaypointLayer (osh-js pml)
- added drawPoint function in adaptors
- updated drawMissionPoint and drawMissionPath to call drawPoint and drawPolyline
- updated the MapPointCollectionEditor to use the DeleteButton
- updated drawpoint to use getColoredIconUrl
- updated drive to location and home location to use generic map drawing functions